### PR TITLE
remove force to C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,4 @@ set(FREEBOX_HEADERS src/client.h
 
 build_addon(pvr.freebox FREEBOX DEPLIBS)
 
-set_property(TARGET pvr.freebox PROPERTY CXX_STANDARD 17)
-
 include(CPack)


### PR DESCRIPTION
Think this not needed and breaks the Raspberry build of the addon?

Was added by this commit https://github.com/aassif/pvr.freebox/commit/b30d1c2f63a07898941c8e6783ad890679429808#diff-af3b638bc2a3e6c650974192a53c7291R33 where also a `stdc++fs` was on libs (whould make sense then). But was removed on https://github.com/aassif/pvr.freebox/commit/d6e2b498c2efe7edbe94388ec2ffa62526547f20#diff-af3b638bc2a3e6c650974192a53c7291L21 and seen nothing in code where C++17 is needed.

By remove the Raspberry build was fixed.

Not sure if needed for future, but thought to ask with it.