### PR TITLE
[Matrix] API change updates

### DIFF
--- a/pvr.freebox/addon.xml.in
+++ b/pvr.freebox/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.freebox"
-  version="2.2.6"
+  version="2.2.7"
   name="PVR Freebox TV"
   provider-name="aassif">
   <requires>@ADDON_DEPENDS@</requires>

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -355,7 +355,7 @@ PVR_ERROR DeleteTimer (const PVR_TIMER & timer, bool force)
 }
 
 PVR_ERROR GetDriveSpace (long long *, long long *) {return PVR_ERROR_NOT_IMPLEMENTED;}
-PVR_ERROR SignalStatus (PVR_SIGNAL_STATUS &) {return PVR_ERROR_NOT_IMPLEMENTED;}
+PVR_ERROR GetSignalStatus (int, PVR_SIGNAL_STATUS *) {return PVR_ERROR_NOT_IMPLEMENTED;}
 
 PVR_ERROR CallMenuHook (const PVR_MENUHOOK & hook, const PVR_MENUHOOK_DATA & d)
 {
@@ -396,7 +396,7 @@ bool SeekTime (double, bool, double *) {return false;}
 void SetSpeed (int) {};
 PVR_ERROR UndeleteRecording (const PVR_RECORDING &) {return PVR_ERROR_NOT_IMPLEMENTED;}
 PVR_ERROR DeleteAllRecordingsFromTrash () {return PVR_ERROR_NOT_IMPLEMENTED;}
-PVR_ERROR GetDescrambleInfo (PVR_DESCRAMBLE_INFO *) {return PVR_ERROR_NOT_IMPLEMENTED;}
+PVR_ERROR GetDescrambleInfo (int, PVR_DESCRAMBLE_INFO *) {return PVR_ERROR_NOT_IMPLEMENTED;}
 PVR_ERROR SetRecordingLifetime (const PVR_RECORDING *) {return PVR_ERROR_NOT_IMPLEMENTED;}
 PVR_ERROR GetStreamTimes (PVR_STREAM_TIMES *) {return PVR_ERROR_NOT_IMPLEMENTED;}
 PVR_ERROR GetStreamProperties (PVR_STREAM_PROPERTIES *) {return PVR_ERROR_NOT_IMPLEMENTED;}

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -206,7 +206,7 @@ void OnPowerSavingDeactivated ()
 {
 }
 
-PVR_ERROR GetAddonCapabilities (PVR_ADDON_CAPABILITIES * caps)
+PVR_ERROR GetCapabilities (PVR_ADDON_CAPABILITIES * caps)
 {
   caps->bSupportsEPG                      = true;
   caps->bSupportsTV                       = true;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -82,7 +82,7 @@ ADDON_STATUS ADDON_Create (void * callbacks, void * properties)
     return ADDON_STATUS_UNKNOWN;
   }
 
-  PVR_PROPERTIES * p = (PVR_PROPERTIES *) properties;
+  AddonProperties_PVR * p = (AddonProperties_PVR *) properties;
 
   XBMC = new CHelper_libXBMC_addon;
   if (! XBMC->RegisterMe (callbacks))


### PR DESCRIPTION
Related to xbmc/xbmc#17775 and to bring in after them.

Only startup and dll load test confirmed and OK, but with lack of hardware not runtime tested.
As general question, is the HW from https://www.free.fr/ also usable outside of France?

This changes are mostly to prepare on Kodi itself for the coming rework to C++ PVR interface and to reduce his change size there.

Further and primary thought do fix part reported here https://github.com/xbmc/xbmc/pull/17764 where his commit included in my Kodi request.