### PR TITLE
Fully implement IsRealTimeStream() - Leia

### DIFF
--- a/pvr.freebox/addon.xml.in
+++ b/pvr.freebox/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.freebox"
-  version="2.0.3"
+  version="2.0.4"
   name="PVR Freebox TV"
   provider-name="aassif">
   <requires>@ADDON_DEPENDS@</requires>

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -55,6 +55,7 @@ bool         colors   = PVR_FREEBOX_DEFAULT_COLORS;
 bool         init     = false;
 ADDON_STATUS status   = ADDON_STATUS_UNKNOWN;
 Freebox    * data     = nullptr;
+bool         isRecordingPlayback = false;
 
 CHelper_libXBMC_addon  * XBMC = nullptr;
 CHelper_libXBMC_pvr    * PVR  = nullptr;
@@ -275,6 +276,8 @@ PVR_ERROR GetChannels (ADDON_HANDLE handle, bool radio)
 
 PVR_ERROR GetChannelStreamProperties (const PVR_CHANNEL * channel, PVR_NAMED_VALUE * properties, unsigned int * count)
 {
+  isRecordingPlayback = false;
+
   return data ? data->GetChannelStreamProperties (channel, properties, count) : PVR_ERROR_SERVER_ERROR;
 }
 
@@ -305,6 +308,8 @@ PVR_ERROR GetRecordings (ADDON_HANDLE handle, bool deleted)
 
 PVR_ERROR GetRecordingStreamProperties (const PVR_RECORDING * recording, PVR_NAMED_VALUE * properties, unsigned int * count)
 {
+  isRecordingPlayback = true;
+
   return data ? data->GetRecordingStreamProperties (recording, properties, count) : PVR_ERROR_SERVER_ERROR;
 }
 
@@ -356,6 +361,11 @@ PVR_ERROR CallMenuHook (const PVR_MENUHOOK & hook, const PVR_MENUHOOK_DATA & d)
   return data ? data->MenuHook (hook, d) : PVR_ERROR_SERVER_ERROR;
 }
 
+bool IsRealTimeStream()
+{ 
+  return !isRecordingPlayback; 
+}
+
 /** UNUSED API FUNCTIONS */
 bool CanPauseStream () {return false;}
 PVR_ERROR OpenDialogChannelScan () {return PVR_ERROR_NOT_IMPLEMENTED;}
@@ -382,7 +392,6 @@ PVR_ERROR GetRecordingEdl (const PVR_RECORDING &, PVR_EDL_ENTRY [], int *) {retu
 void DemuxAbort () {}
 bool IsTimeshifting () {return false;}
 DemuxPacket * DemuxRead () {return NULL;}
-bool IsRealTimeStream () {return true;}
 void PauseStream (bool) {}
 bool CanSeekStream () {return false;}
 bool SeekTime (double, bool, double *) {return false;}


### PR DESCRIPTION
v2.0.4
- Fully implement IsRealTimeStream()

The change is related to a change in kodi whereby this function can be called when playing back a recording. If not correctly set the fast forward/rewind buttons can be missing.

Don't merge and release just yet as we need to fix a Jenkins issue first for the Leia build.