### PR TITLE
[Matrix] API update

### DIFF
--- a/pvr.freebox/addon.xml.in
+++ b/pvr.freebox/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.freebox"
-  version="5.0.2"
+  version="6.0.0"
   name="PVR Freebox TV"
   provider-name="aassif">
   <requires>@ADDON_DEPENDS@</requires>


### PR DESCRIPTION
API related to xbmc/xbmc#17438 (API changed DEMUX_PACKET not used there)

Before was the inputstream addon API not in clean "C" between Kodi and addon. PVR use also his DEMUX_PACKET thats why it must be recreated too.