### PR TITLE
[Nexus] Add supports recordings delete capability for PVR API 8.0.0

### DIFF
--- a/pvr.freebox/addon.xml.in
+++ b/pvr.freebox/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.freebox"
-  version="20.0.0"
+  version="20.1.0"
   name="PVR Freebox TV"
   provider-name="aassif">
   <requires>@ADDON_DEPENDS@</requires>

--- a/src/Freebox.cpp
+++ b/src/Freebox.cpp
@@ -1290,6 +1290,7 @@ PVR_ERROR Freebox::GetCapabilities (kodi::addon::PVRCapabilities & caps)
   caps.SetSupportsRadio                    (false);
   caps.SetSupportsChannelGroups            (false);
   caps.SetSupportsRecordings               (true);
+  caps.SetSupportsRecordingsDelete         (true);
   caps.SetSupportsRecordingSize            (true);
   caps.SetSupportsRecordingsRename         (true);
   caps.SetSupportsRecordingsUndelete       (false);


### PR DESCRIPTION
- Kodi API to 8.0.0
  - Add supports recordings delete capability
  - Enforce EDL limits

This PR should be rebuilt after these xbmc PRs are merged:
- https://github.com/xbmc/xbmc/pull/20009
- https://github.com/xbmc/xbmc/pull/19395

**NOTE:** Wait until requests on Kodi are in.