### PR TITLE
[openssl] bypass android conf NDK detection

### DIFF
--- a/depends/common/openssl/01-android.patch
+++ b/depends/common/openssl/01-android.patch
@@ -1,0 +1,30 @@
+--- a/Configurations/15-android.conf
++++ b/Configurations/15-android.conf
+@@ -184,10 +184,9 @@
+         # systems are perfectly capable of executing binaries targeting
+         # Froyo. Keep in mind that in the nutshell Android builds are
+         # about JNI, i.e. shared libraries, not applications.
+-        cflags           => add(sub { android_ndk()->{cflags} }),
+-        cppflags         => add(sub { android_ndk()->{cppflags} }),
+-        cxxflags         => add(sub { android_ndk()->{cflags} }),
+-        bn_ops           => sub { android_ndk()->{bn_ops} },
++        cflags           => add("\$(CFLAGS)"),
++        cppflags         => add("\$(CPPFLAGS)"),
++        cxxflags         => add("\$(CXXFLAGS)"),
+         bin_cflags       => "-pie",
+         enable           => [ ],
+     },
+@@ -220,11 +219,11 @@
+         # Newer NDK versions reportedly require additional -latomic.
+         #
+         inherit_from     => [ "android", asm("armv4_asm") ],
+-        bn_ops           => add("RC4_CHAR"),
++        bn_ops           => add("RC4_CHAR BN_LLONG"),
+     },
+     "android-arm64" => {
+         inherit_from     => [ "android", asm("aarch64_asm") ],
+-        bn_ops           => add("RC4_CHAR"),
++        bn_ops           => add("RC4_CHAR SIXTY_FOUR_BIT_LONG"),
+         perlasm_scheme   => "linux64",
+     },
+ 


### PR DESCRIPTION
Looks to work.

This is how i would fix your openssl issue. Rather than rely on the generic detections of NDK info in openssl, we know all that info already. So just patch to use our data for the relevant flags.

i do custom config files for Kodi apple platforms and its use of openssl. its just easier than trying to work within openssl's definitions.

I would advise you have someone test the resulting android build artifacts to confirm things are ok.