### PR TITLE
fix compile warnings

### DIFF
--- a/src/Freebox.cpp
+++ b/src/Freebox.cpp
@@ -591,6 +591,7 @@ PVR_ERROR Freebox::Channel::GetStreamProperties (enum Source source,
     {
       case Protocol::RTSP : properties.emplace_back (PVR_STREAM_PROPERTY_STREAMURL, streams[index].rtsp); break;
       case Protocol::HLS  : properties.emplace_back (PVR_STREAM_PROPERTY_STREAMURL, streams[index].hls);  break;
+      default: break;
     }
 
     properties.emplace_back (PVR_STREAM_PROPERTY_ISREALTIMESTREAM, "true");
@@ -755,7 +756,7 @@ bool Freebox::ProcessChannels ()
   // Conflicts by major.
   map<int, Conflicts> conflicts_by_major;
 
-  for (int i = 0; i < bouquet.size (); ++i)
+  for (unsigned int i = 0; i < bouquet.size (); ++i)
   {
     string uuid  = bouquet[i]["uuid"];
     int    major = bouquet[i]["number"];


### PR DESCRIPTION
./src/Freebox.cpp: In member function 'PVR_ERROR Freebox::Channel::GetStreamProperties(Freebox::Source, Freebox::Quality, Freebox::Protocol, std::vector<kodi::addon::PVRStreamProperty>&) const': ./src/Freebox.cpp:590:12: warning: enumeration value 'DEFAULT' not handled in switch [-Wswitch]
  590 |     switch (protocol)
      |            ^
./src/Freebox.cpp: In member function 'bool Freebox::ProcessChannels()':
./src/Freebox.cpp:758:21: warning: comparison of integer expressions of different signedness: 'int' and 'nlohmann::json_abi_v3_11_3::basic_json<>::size_type' {aka 'unsigned int'} [-Wsign-compare]
  758 |   for (int i = 0; i < bouquet.size (); ++i)
      |                   ~~^~~~~~~~~~~~~~~~~